### PR TITLE
Add "just" as bin name to package.json

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -48,7 +48,7 @@ The recommended way to install `rust-just` is as a global dependency:
 and then run with:
 
 ```
-~/$ rust-just [OPTIONS] [ARGUMENTS]...
+~/$ just [OPTIONS] [ARGUMENTS]...
 ```
 
 ### Installation as local dependency
@@ -64,7 +64,7 @@ and then run with:
 > For example:
 > 
 > ```
-> ~/$ rust-just --execaoptions '{"stdio": "inherit", "reject": false}' [OPTIONS] [ARGUMENTS]...
+> ~/$ just --execaoptions '{"stdio": "inherit", "reject": false}' [OPTIONS] [ARGUMENTS]...
 > ```
 > 
 > For a complete list of available Execa options, refer to the [Execa API documentation](https://github.com/sindresorhus/execa/blob/main/docs/api.md#options-1).

--- a/npm/rust-just/package.json
+++ b/npm/rust-just/package.json
@@ -2,7 +2,10 @@
   "name": "rust-just",
   "version": "1.39.0",
   "description": "🤖 Just a command runner",
-  "bin": "lib/index.mjs",
+  "bin": {
+    "just": "lib/index.mjs",
+    "rust-just": "lib/index.mjs"
+  },
   "exports": {
     ".": {
       "import": "./lib/index.mjs"

--- a/npm/rust-just/yarn.lock
+++ b/npm/rust-just/yarn.lock
@@ -2445,6 +2445,7 @@ __metadata:
     rust-just-windows-x64:
       optional: true
   bin:
+    just: lib/index.mjs
     rust-just: lib/index.mjs
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This makes it possible to either execute it as `$ npx just` as well as `$ npx rust-just`